### PR TITLE
fix: getSigninUrl is not static method

### DIFF
--- a/src/Auth/Url.php
+++ b/src/Auth/Url.php
@@ -21,7 +21,7 @@ class Url
         }
     }
 
-    public function getSigninUrl(string $redirectUri, AuthConfig $authConfig): string
+    public static function getSigninUrl(string $redirectUri, AuthConfig $authConfig): string
     {
         // $origin = 'https://door.casbin.com';
         // $redirectUri = sprintf('%s/callback', $origin);


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor-php-sdk/issues/33