### PR TITLE
feat: fix bug that GetUsers() API doesn't return array

### DIFF
--- a/src/Auth/User.php
+++ b/src/Auth/User.php
@@ -305,7 +305,7 @@ class User
 
         $url = sprintf("%s/api/get-users?owner=%s&clientId=%s&clientSecret=%s", self::$authConfig->endpoint, self::$authConfig->organizationName, self::$authConfig->clientId, self::$authConfig->clientSecret);
         $stream = Util::doGetStream($url, self::$authConfig);
-        $users = json_decode($stream->__toString());
+        $users = json_decode($stream->__toString(), true);
         return $users;
     }
 


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor-php-sdk

In User.php file, getUsers function not returned array object cause fatal error exception.

Fatal error: Uncaught TypeError: Return value of Casdoor\Auth\User::getUsers() must be of the type array, object returned in E:\service\php\vendor\casdoor\casdoor-php-sdk\src\Auth\User.php:310 Stack trace: #0 E:\service\php\OauthTest.php(51): Casdoor\Auth\User::getUsers() #1 E:\service\php\OauthTest.php(84): Casdoor\Tests\testGetUsers() #2 {main} thrown in E:\service\php\vendor\casdoor\casdoor-php-sdk\src\Auth\User.php on line 310